### PR TITLE
fix(auth): fix authorization validations

### DIFF
--- a/src/modules/event-staff-invitations/event-staff.invitations.service.ts
+++ b/src/modules/event-staff-invitations/event-staff.invitations.service.ts
@@ -38,8 +38,12 @@ export class EventStaffInvitationsService {
     private usersService: UsersService,
   ) {}
 
-  async create(eventId: string, body: CreateEventStaffInvitationDto): Promise<EventStaffInvitationResponseDto> {
-    const userId = await this.sendInvitationEmail(body.email, eventId)
+  async create(
+    organizerId: string,
+    eventId: string,
+    body: CreateEventStaffInvitationDto,
+  ): Promise<EventStaffInvitationResponseDto> {
+    const userId = await this.sendInvitationEmail(organizerId, body.email, eventId)
     const staffInvitation = this.staffInvitationRepo.create({
       ...body,
       eventId,
@@ -51,8 +55,11 @@ export class EventStaffInvitationsService {
     return { data: plainToInstance(EventStaffInvitationDataDto, data) }
   }
 
-  async acceptInvitation(id: string): Promise<EventStaffResponseDto> {
+  async acceptInvitation(userId: string, id: string): Promise<EventStaffResponseDto> {
     const { data: invitation } = await this.getById(id)
+    if (invitation.userId !== userId) {
+      throw new BadRequestException('This invitation is not for you')
+    }
     await this.validateBeforeAccept(invitation.eventId)
 
     await this.staffInvitationRepo.update(id, {
@@ -67,15 +74,22 @@ export class EventStaffInvitationsService {
     })
   }
 
-  async rejectInvitation(id: string): Promise<{ message: string }> {
-    await this.getById(id)
+  async rejectInvitation(userId: string, id: string): Promise<{ message: string }> {
+    const { data: invitation } = await this.getById(id)
+    if (invitation.userId !== userId) {
+      throw new BadRequestException('This invitation is not for you')
+    }
     await this.staffInvitationRepo.update(id, { invitationStatus: EventStaffInvitationStatus.REJECTED })
 
     return { message: 'Invitation rejected successfully' }
   }
 
-  async cancelInvitation(id: string): Promise<{ message: string }> {
-    await this.getById(id)
+  async cancelInvitation(organizerId: string, id: string): Promise<{ message: string }> {
+    const { data: invitation } = await this.getById(id)
+    const { data: event } = await this.eventsService.getById(invitation.eventId)
+    if (event.organizer.id !== organizerId) {
+      throw new BadRequestException('You are not the organizer of this event')
+    }
     await this.staffInvitationRepo.update(id, { invitationStatus: EventStaffInvitationStatus.CANCELED })
     return { message: 'Invitation canceled successfully' }
   }
@@ -197,7 +211,7 @@ export class EventStaffInvitationsService {
     }
   }
 
-  private async sendInvitationEmail(email: string, eventId: string): Promise<string> {
+  private async sendInvitationEmail(organizerId: string, email: string, eventId: string): Promise<string> {
     const user = await this.usersService.findByEmail(email)
     if (!user) {
       throw new NotFoundException('User not found')
@@ -206,7 +220,7 @@ export class EventStaffInvitationsService {
     const { data: event } = await this.eventsService.getById(eventId)
 
     await this.checkIfInvitationExists(user.id, eventId)
-    this.validateEvent(event.organizer.id, event, user.id)
+    this.validateEvent(organizerId, event, user.id)
 
     // const organizerName = event.organizer.name
     // const eventName = event.title

--- a/src/modules/event-staff-invitations/event-staff.invitations.service.ts
+++ b/src/modules/event-staff-invitations/event-staff.invitations.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { plainToInstance } from 'class-transformer'
 import { Repository, SelectQueryBuilder } from 'typeorm'
@@ -58,7 +58,7 @@ export class EventStaffInvitationsService {
   async acceptInvitation(userId: string, id: string): Promise<EventStaffResponseDto> {
     const { data: invitation } = await this.getById(id)
     if (invitation.userId !== userId) {
-      throw new BadRequestException('This invitation is not for you')
+      throw new ForbiddenException('This invitation is not for you')
     }
     await this.validateBeforeAccept(invitation.eventId)
 
@@ -77,7 +77,7 @@ export class EventStaffInvitationsService {
   async rejectInvitation(userId: string, id: string): Promise<{ message: string }> {
     const { data: invitation } = await this.getById(id)
     if (invitation.userId !== userId) {
-      throw new BadRequestException('This invitation is not for you')
+      throw new ForbiddenException('This invitation is not for you')
     }
     await this.staffInvitationRepo.update(id, { invitationStatus: EventStaffInvitationStatus.REJECTED })
 
@@ -88,7 +88,7 @@ export class EventStaffInvitationsService {
     const { data: invitation } = await this.getById(id)
     const { data: event } = await this.eventsService.getById(invitation.eventId)
     if (event.organizer.id !== organizerId) {
-      throw new BadRequestException('You are not the organizer of this event')
+      throw new ForbiddenException('You are not the organizer of this event')
     }
     await this.staffInvitationRepo.update(id, { invitationStatus: EventStaffInvitationStatus.CANCELED })
     return { message: 'Invitation canceled successfully' }
@@ -153,7 +153,7 @@ export class EventStaffInvitationsService {
     }
 
     if (event.organizer.id !== organizerId) {
-      throw new BadRequestException('You are not the organizer of this event')
+      throw new ForbiddenException('You are not the organizer of this event')
     }
 
     if (userId === organizerId) {

--- a/src/modules/event-staff-invitations/event-staff.invitations.service.ts
+++ b/src/modules/event-staff-invitations/event-staff.invitations.service.ts
@@ -164,7 +164,7 @@ export class EventStaffInvitationsService {
   private buildBaseQuery(): SelectQueryBuilder<EventStaffInvitations> {
     return this.staffInvitationRepo
       .createQueryBuilder('esi')
-      .select(['esi.id', 'esi.originalAccessLevel', 'esi.invitationStatus', 'u.id', 'u.name', 'u.email', 'u.avatarUrl'])
+      .select(['esi.id', 'esi.userId', 'esi.eventId', 'esi.originalAccessLevel', 'esi.invitationStatus', 'u.id', 'u.name', 'u.email', 'u.avatarUrl'])
       .innerJoin('esi.user', 'u')
   }
 

--- a/src/modules/event-staff-invitations/staff-invites.controller.ts
+++ b/src/modules/event-staff-invitations/staff-invites.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
+import type { AuthenticatedRequest } from '~/common/interfaces/req.interface'
 import { MessageDto } from '~/common/dto/message.dto'
 import {
   CreateEventStaffInvitationDto,
@@ -26,10 +27,11 @@ export class StaffInvitesController {
   })
   @ApiResponse({ status: 400, description: 'Bad request.' })
   async create(
+    @Req() req: AuthenticatedRequest,
     @Param('eventId') eventId: string,
     @Body() body: CreateEventStaffInvitationDto,
   ): Promise<EventStaffInvitationResponseDto> {
-    return this.eventStaffInvitationsService.create(eventId, body)
+    return this.eventStaffInvitationsService.create(req.user.id, eventId, body)
   }
 
   @Post(':invitationId/cancel')
@@ -40,8 +42,11 @@ export class StaffInvitesController {
     type: MessageDto,
     description: 'The invitation has been canceled.',
   })
-  async cancelInvitation(@Param('invitationId') invitationId: string): Promise<MessageDto> {
-    return this.eventStaffInvitationsService.cancelInvitation(invitationId)
+  async cancelInvitation(
+    @Req() req: AuthenticatedRequest,
+    @Param('invitationId') invitationId: string,
+  ): Promise<MessageDto> {
+    return this.eventStaffInvitationsService.cancelInvitation(req.user.id, invitationId)
   }
 
   @Get('events/:eventId')

--- a/src/modules/event-staff-invitations/users-invitations.controller.ts
+++ b/src/modules/event-staff-invitations/users-invitations.controller.ts
@@ -24,8 +24,11 @@ export class UserInvitationsController {
     type: EventStaffResponseDto,
     description: 'The invitation has been accepted.',
   })
-  async acceptInvitation(@Param('invitationId') invitationId: string): Promise<EventStaffResponseDto> {
-    return this.eventStaffInvitationsService.acceptInvitation(invitationId)
+  async acceptInvitation(
+    @Req() req: AuthenticatedRequest,
+    @Param('invitationId') invitationId: string,
+  ): Promise<EventStaffResponseDto> {
+    return this.eventStaffInvitationsService.acceptInvitation(req.user.id, invitationId)
   }
 
   @Post(':invitationId/reject')
@@ -36,8 +39,11 @@ export class UserInvitationsController {
     type: MessageDto,
     description: 'The invitation has been rejected.',
   })
-  async rejectInvitation(@Param('invitationId') invitationId: string): Promise<MessageDto> {
-    return this.eventStaffInvitationsService.rejectInvitation(invitationId)
+  async rejectInvitation(
+    @Req() req: AuthenticatedRequest,
+    @Param('invitationId') invitationId: string,
+  ): Promise<MessageDto> {
+    return this.eventStaffInvitationsService.rejectInvitation(req.user.id, invitationId)
   }
 
   @Get('me')

--- a/src/modules/event-staff/event-staff.controller.ts
+++ b/src/modules/event-staff/event-staff.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Query, UseGuards } from '@nestjs/common'
+import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Query, Req, UseGuards } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
+import type { AuthenticatedRequest } from '~/common/interfaces/req.interface'
 import { MessageDto } from '~/common/dto/message.dto'
 import {
   EventStaffResponseDto,
@@ -24,10 +25,11 @@ export class EventStaffController {
   @ApiResponse({ status: 400, description: 'Bad request' })
   @ApiResponse({ status: 404, description: 'Staff not found' })
   async updateAccessLevel(
+    @Req() req: AuthenticatedRequest,
     @Param('staffId') staffId: string,
     @Body() body: UpdateAccessLevelDto,
   ): Promise<EventStaffResponseDto> {
-    return this.eventStaffService.updateAccessLevel(staffId, body.accessLevel)
+    return this.eventStaffService.updateAccessLevel(req.user.id, staffId, body.accessLevel)
   }
 
   @Get(':eventId/staff')
@@ -35,8 +37,12 @@ export class EventStaffController {
   @ApiParam({ name: 'eventId', type: String, description: 'The ID of the event' })
   @ApiQuery({ type: QueryEventStaffDto })
   @ApiResponse({ status: 200, type: PaginateEventStaffDto, description: 'The list of staff for the event.' })
-  async getAll(@Param('eventId') eventId: string, @Query() query: QueryEventStaffDto): Promise<PaginateEventStaffDto> {
-    return this.eventStaffService.getByEventId(eventId, query)
+  async getAll(
+    @Req() req: AuthenticatedRequest,
+    @Param('eventId') eventId: string,
+    @Query() query: QueryEventStaffDto,
+  ): Promise<PaginateEventStaffDto> {
+    return this.eventStaffService.getByEventId(req.user.id, eventId, query)
   }
 
   @Get('staff/:staffId')
@@ -44,8 +50,8 @@ export class EventStaffController {
   @ApiParam({ name: 'staffId' })
   @ApiResponse({ status: 200, type: EventStaffResponseDto })
   @ApiResponse({ status: 404, description: 'Staff not found' })
-  async getById(@Param('staffId') staffId: string): Promise<EventStaffResponseDto> {
-    return this.eventStaffService.getById(staffId)
+  async getById(@Req() req: AuthenticatedRequest, @Param('staffId') staffId: string): Promise<EventStaffResponseDto> {
+    return this.eventStaffService.getById(req.user.id, staffId)
   }
 
   @Delete('staff/:staffId')
@@ -54,7 +60,7 @@ export class EventStaffController {
   @ApiParam({ name: 'staffId' })
   @ApiResponse({ status: 204, description: 'The staff has been deleted successfully' })
   @ApiResponse({ status: 404, description: 'Staff not found' })
-  async deleteStaff(@Param('staffId') staffId: string): Promise<void> {
-    return this.eventStaffService.deleteStaff(staffId)
+  async deleteStaff(@Req() req: AuthenticatedRequest, @Param('staffId') staffId: string): Promise<void> {
+    return this.eventStaffService.deleteStaff(req.user.id, staffId)
   }
 }

--- a/src/modules/event-staff/event-staff.service.ts
+++ b/src/modules/event-staff/event-staff.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { plainToInstance } from 'class-transformer'
 import { Repository, SelectQueryBuilder } from 'typeorm'
@@ -14,12 +14,14 @@ import {
 } from '~/modules/event-staff/dto/event-staff.dto'
 import { EventStaff } from '~/modules/event-staff/event-staff.entity'
 import { CreateEventStaff } from '~/modules/event-staff/interfaces/event-staff.interface'
+import { EventsService } from '~/modules/events-module/events.service'
 
 @Injectable()
 export class EventStaffService {
   constructor(
     @InjectRepository(EventStaff)
     private eventStaffRepository: Repository<EventStaff>,
+    private eventsService: EventsService,
   ) {}
 
   async create(body: CreateEventStaff): Promise<EventStaffResponseDto> {
@@ -29,16 +31,24 @@ export class EventStaffService {
     return { data: plainToInstance(EventStaffDataDto, data) }
   }
 
-  async updateAccessLevel(staffId: string, accessLevel: EventStaffAccessLevel): Promise<EventStaffResponseDto> {
-    const updated = await this.eventStaffRepository.update(staffId, { accessLevel })
-    if (updated.affected === 0) {
+  async updateAccessLevel(
+    userId: string,
+    staffId: string,
+    accessLevel: EventStaffAccessLevel,
+  ): Promise<EventStaffResponseDto> {
+    const staff = await this.eventStaffRepository.findOne({ where: { id: staffId }, select: ['eventId', 'id'] })
+    if (!staff) {
       throw new NotFoundException('Event staff not found')
     }
+    await this.validateOrganizer(userId, staff.eventId)
 
-    return this.getById(staffId)
+    await this.eventStaffRepository.update(staffId, { accessLevel })
+    return this.getById(userId, staffId)
   }
 
-  async getByEventId(eventId: string, queryParams: QueryEventStaffDto): Promise<PaginateEventStaffDto> {
+  async getByEventId(userId: string, eventId: string, queryParams: QueryEventStaffDto): Promise<PaginateEventStaffDto> {
+    await this.validateOrganizer(userId, eventId)
+
     const { page, limit, ...filters } = queryParams
     const query = this.buildBaseQuery()
       .where('es.eventId = :eventId', { eventId })
@@ -53,18 +63,29 @@ export class EventStaffService {
     }
   }
 
-  async getById(id: string): Promise<EventStaffResponseDto> {
+  async getById(userId: string, id: string): Promise<EventStaffResponseDto> {
     const data = await this.buildBaseQuery().where('es.id = :id', { id }).getOne()
     if (!data) {
       throw new NotFoundException('Event staff not found')
     }
+    await this.validateOrganizer(userId, data.eventId)
     return { data: plainToInstance(EventStaffDataDto, data) }
   }
 
-  async deleteStaff(staffId: string): Promise<void> {
-    const deleted = await this.eventStaffRepository.delete(staffId)
-    if (deleted.affected === 0) {
+  async deleteStaff(userId: string, staffId: string): Promise<void> {
+    const staff = await this.eventStaffRepository.findOne({ where: { id: staffId }, select: ['eventId', 'id'] })
+    if (!staff) {
       throw new NotFoundException('Event staff not found')
+    }
+    await this.validateOrganizer(userId, staff.eventId)
+
+    await this.eventStaffRepository.delete(staffId)
+  }
+
+  private async validateOrganizer(userId: string, eventId: string): Promise<void> {
+    const { data: event } = await this.eventsService.getById(eventId)
+    if (event.organizer.id !== userId) {
+      throw new BadRequestException('You are not the organizer of this event')
     }
   }
 
@@ -89,6 +110,7 @@ export class EventStaffService {
       .createQueryBuilder('es')
       .select([
         'es.id',
+        'es.eventId',
         'es.accessLevel',
         'es.invitationStatus',
         'es.staffInvitationId',

--- a/src/modules/event-staff/event-staff.service.ts
+++ b/src/modules/event-staff/event-staff.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { plainToInstance } from 'class-transformer'
 import { Repository, SelectQueryBuilder } from 'typeorm'

--- a/src/modules/event-staff/event-staff.service.ts
+++ b/src/modules/event-staff/event-staff.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { plainToInstance } from 'class-transformer'
 import { Repository, SelectQueryBuilder } from 'typeorm'
@@ -85,7 +85,7 @@ export class EventStaffService {
   private async validateOrganizer(userId: string, eventId: string): Promise<void> {
     const { data: event } = await this.eventsService.getById(eventId)
     if (event.organizer.id !== userId) {
-      throw new BadRequestException('You are not the organizer of this event')
+      throw new ForbiddenException('You are not the organizer of this event')
     }
   }
 

--- a/src/modules/events-module/events.controller.ts
+++ b/src/modules/events-module/events.controller.ts
@@ -32,8 +32,8 @@ export class EventsController {
   @ApiResponse({ status: 200, description: 'The event has been successfully cancelled.' })
   @ApiResponse({ status: 400, description: 'Bad request.' })
   @ApiResponse({ status: 404, description: 'Event not found.' })
-  async cancel(@Param('id') id: string): Promise<void> {
-    return this.eventsService.cancel(id)
+  async cancel(@Req() req: AuthenticatedRequest, @Param('id') id: string): Promise<void> {
+    return this.eventsService.cancel(req.user.id, id)
   }
 
   @Patch(':id')
@@ -73,7 +73,7 @@ export class EventsController {
   @ApiParam({ name: 'id', description: 'The ID of the event' })
   @ApiResponse({ status: 200, description: 'The event has been successfully deleted.' })
   @ApiResponse({ status: 404, description: 'Event not found.' })
-  async delete(@Param('id') id: string): Promise<void> {
-    return this.eventsService.delete(id)
+  async delete(@Req() req: AuthenticatedRequest, @Param('id') id: string): Promise<void> {
+    return this.eventsService.delete(req.user.id, id)
   }
 }

--- a/src/modules/events-module/events.service.ts
+++ b/src/modules/events-module/events.service.ts
@@ -69,21 +69,21 @@ export class EventsService {
     return { data: plainToInstance(EventDataDto, event) }
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(organizerId: string, id: string): Promise<void> {
     const { data: event } = await this.getById(id)
-    this.validateOrganizer(event.organizer.id, event)
+    this.validateOrganizer(organizerId, event)
     if (event.status !== EventStatus.DRAFT) {
       throw new BadRequestException('Event cannot be deleted because it is not draft')
     }
     await this.eventsRepository.delete(id)
   }
 
-  async cancel(id: string): Promise<void> {
+  async cancel(organizerId: string, id: string): Promise<void> {
     const { data: event } = await this.getById(id)
-    this.validateOrganizer(event.organizer.id, event)
+    this.validateOrganizer(organizerId, event)
     if (event.status === EventStatus.OPENED || event.status === EventStatus.GOING) {
       await this.eventsRepository.update(id, { status: EventStatus.CANCELED })
-      await this.eventChangesService.create(event.organizer.id, id, {
+      await this.eventChangesService.create(organizerId, id, {
         changedFields: ['status'],
         oldValue: { status: event.status },
         newValue: { status: EventStatus.CANCELED },

--- a/src/modules/organizer-payment-info/organizer-payment-info.controller.ts
+++ b/src/modules/organizer-payment-info/organizer-payment-info.controller.ts
@@ -1,6 +1,20 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post, Query, UseGuards } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
+import type { AuthenticatedRequest } from '~/common/interfaces/req.interface'
 import { QueryPaginationDto } from '~/common/pagination/pagination.dto'
 import {
   CreateOrganizerPaymentInfoDto,
@@ -34,9 +48,13 @@ export class OrganizerPaymentInfoController {
   @ApiResponse({ status: 400, description: 'Bad request' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async createOrganizerPaymentInfo(
+    @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
     @Body() body: CreateOrganizerPaymentInfoDto,
   ): Promise<OrganizerPaymentInfoResDto> {
+    if (req.user.id !== id) {
+      throw new ForbiddenException('You can only create your own payment info')
+    }
     return this.organizerPaymentInfoService.create(id, body)
   }
 
@@ -52,10 +70,11 @@ export class OrganizerPaymentInfoController {
   @ApiResponse({ status: 400, description: 'Bad request' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async updateOrganizerPaymentInfo(
+    @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
     @Body() body: UpdateOrganizerPaymentInfoDto,
   ): Promise<OrganizerPaymentInfoResDto> {
-    return this.organizerPaymentInfoService.update(id, body)
+    return this.organizerPaymentInfoService.update(req.user.id, id, body)
   }
 
   @Get(':id/organizer-payment-info')
@@ -70,9 +89,13 @@ export class OrganizerPaymentInfoController {
   @ApiResponse({ status: 400, description: 'Bad request' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async getOrganizerPaymentInfosByUserId(
+    @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
     @Query() query: QueryPaginationDto,
   ): Promise<OrganizerPaymentInfoPageDto> {
+    if (req.user.id !== id) {
+      throw new ForbiddenException('You can only list your own payment info')
+    }
     return this.organizerPaymentInfoService.listByUserId(id, query)
   }
 
@@ -86,8 +109,11 @@ export class OrganizerPaymentInfoController {
   })
   @ApiResponse({ status: 400, description: 'Bad request' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
-  async getOrganizerPaymentInfoById(@Param('id') id: string): Promise<OrganizerPaymentInfoResDto> {
-    return this.organizerPaymentInfoService.getById(id)
+  async getOrganizerPaymentInfoById(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+  ): Promise<OrganizerPaymentInfoResDto> {
+    return this.organizerPaymentInfoService.getById(req.user.id, id)
   }
 
   @Delete('organizer-payment-info/:id')
@@ -97,7 +123,7 @@ export class OrganizerPaymentInfoController {
   @ApiResponse({ status: 200, description: 'Organizer payment info deleted successfully' })
   @ApiResponse({ status: 400, description: 'Bad request' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
-  async deleteOrganizerPaymentInfoById(@Param('id') id: string): Promise<void> {
-    return this.organizerPaymentInfoService.delete(id)
+  async deleteOrganizerPaymentInfoById(@Req() req: AuthenticatedRequest, @Param('id') id: string): Promise<void> {
+    return this.organizerPaymentInfoService.delete(req.user.id, id)
   }
 }

--- a/src/modules/organizer-payment-info/organizer-payment-info.service.ts
+++ b/src/modules/organizer-payment-info/organizer-payment-info.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { plainToInstance } from 'class-transformer'
 import { Repository } from 'typeorm'
@@ -37,11 +37,11 @@ export class OrganizerPaymentInfoService {
     return { data: plainToInstance(OrganizerPaymentInfoDataDto, data) }
   }
 
-  async update(id: string, body: UpdateOrganizerPaymentInfoDto): Promise<OrganizerPaymentInfoResDto> {
-    const current = await this.getById(id)
+  async update(userId: string, id: string, body: UpdateOrganizerPaymentInfoDto): Promise<OrganizerPaymentInfoResDto> {
+    const current = await this.getById(userId, id)
     await this.validateBody({ ...current.data, ...body })
     await this.organizerPaymentInfoRepository.update(id, body)
-    return this.getById(id)
+    return this.getById(userId, id)
   }
 
   async listByUserId(userId: string, query: QueryPaginationDto): Promise<OrganizerPaymentInfoPageDto> {
@@ -60,21 +60,31 @@ export class OrganizerPaymentInfoService {
     }
   }
 
-  async getById(id: string): Promise<OrganizerPaymentInfoResDto> {
+  async getById(userId: string, id: string): Promise<OrganizerPaymentInfoResDto> {
     const organizerPaymentInfo = await this.organizerPaymentInfoRepository.findOne({ where: { id } })
     if (!organizerPaymentInfo) {
       throw new NotFoundException('Organizer payment info not found')
+    }
+    if (organizerPaymentInfo.userId !== userId) {
+      throw new ForbiddenException('You do not own this payment info')
     }
     return {
       data: plainToInstance(OrganizerPaymentInfoDataDto, organizerPaymentInfo, { excludeExtraneousValues: true }),
     }
   }
 
-  async delete(id: string): Promise<void> {
-    const { affected } = await this.organizerPaymentInfoRepository.delete(id)
-    if (affected === 0) {
+  async delete(userId: string, id: string): Promise<void> {
+    const organizerPaymentInfo = await this.organizerPaymentInfoRepository.findOne({
+      where: { id },
+      select: ['id', 'userId'],
+    })
+    if (!organizerPaymentInfo) {
       throw new NotFoundException('Organizer payment info not found')
     }
+    if (organizerPaymentInfo.userId !== userId) {
+      throw new ForbiddenException('You do not own this payment info')
+    }
+    await this.organizerPaymentInfoRepository.delete(id)
   }
 
   // used to check if user is a organizer


### PR DESCRIPTION
Replace tautological organizer checks with proper JWT-based authorization across the codebase.

Events:
- cancel() and delete() now receive `@Req()` and pass req.user.id to the service instead of event.organizer.id

Event-Staff:
- All 4 endpoints (updateAccessLevel, getByEventId, getById, deleteStaff) inject `@Req()` and validate organizer via EventsService

Staff-Invitations:
- create and cancelInvitation verify organizerId from the JWT token
- acceptInvitation and rejectInvitation validate the invitation belongs to the authenticated user

Organizer-Payment-Info:
- All endpoints inject `@Req()`; create and listByUserId compare req.user.id against `@Param('id')`; getById and delete check ownership at the service layer with ForbiddenException